### PR TITLE
Modify zookeeper console log format to match Splunk's.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,10 @@ MAINTAINER Mike Lloyd <mike_lloyd@kevin.michael.lloyd@gmail.com>
 # enable incremental garbage collection and set the heap to max at 2GB.
 ENV _JAVA_OPTIONS "-Xmx2G -Xincgc"
 
-# get zookeeper 3.5.0-alpha
-RUN curl -fLk http://apache.cs.utah.edu/zookeeper/zookeeper-3.5.0-alpha/zookeeper-3.5.0-alpha.tar.gz | tar xzf - -C /opt
-RUN mv /opt/zookeeper-3.5.0-alpha /opt/zookeeper
+# get zookeeper 3.4.8
+RUN curl -fLk http://archive.apache.org/dist/zookeeper/zookeeper-3.4.8/zookeeper-3.4.8.tar.gz | tar xzf - -C /opt
+RUN mv /opt/zookeeper-3.4.8 /opt/zookeeper
+
 
 # create the configs and default data dir of /tmp/zookeeper
 RUN mkdir /tmp/zookeeper/
@@ -38,6 +39,9 @@ RUN mkdir /tmp/zookeeper/
 COPY zkcfg /usr/local/bin
 COPY run.sh /opt/zookeeper/bin
 COPY prestage.sh /opt/zookeeper/bin
+COPY log4j.properties /opt/zookeeper/conf
+COPY zkServer.sh /opt/zookeeper/bin
+
 
 ENV PATH=/opt/zookeeper/bin:${PATH} \
     ZOO_LOG4J_PROP="INFO, CONSOLE"

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@
 all:
 	go clean
 	GOARCH=amd64 GOOS=linux go build -v zkcfg.go
-	docker build --no-cache -t zookeeper:3.5.0-alpha .
+	docker build --no-cache -t zookeeper:3.4.8 .
 
 clean:
 	go clean
-	docker rmi -f zookeeper:3.5.0-alpha
+	docker rmi -f zookeeper:3.4.8
 	docker rmi $(docker images -f "dangling=true" -q)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To run this locally while creating new folder paths:
 
 1. `make`
 1. `docker run -d --net="host" -p 2181:2181 -p 2888:2888 -p 3888:3888 -e MYID=1 -e ZOOKEEPER_01_SERVICE_HOST=localhost 
--e LAB=1 -e BUCKET_1=Folder1 -e BUCKET_2=Folder2 zookeeper:3.5.0-alpha`
+-e LAB=1 -e BUCKET_1=Folder1 -e BUCKET_2=Folder2 zookeeper:3.4.8`
 
 To run this within a Kubernetes cluster:
 
@@ -33,7 +33,7 @@ Here is an example service configuration.
   "kind": "Service",
   "metadata": {
     "name": "zookeeper-01",
-    "version": "3.5.0"
+    "version": "3.4.8"
   },
   "spec": {
     "ports": [
@@ -66,7 +66,7 @@ Here is an example replication controller configuration:
   "kind": "ReplicationController",
   "metadata": {
     "name": "zookeeper-01",
-    "version": "3.5.0"
+    "version": "3.4.8"
   },
   "spec": {
     "replicas": 1,
@@ -86,7 +86,7 @@ Here is an example replication controller configuration:
                 "value": "1"
               }
             ],
-            "image": "zookeeper:3.5.0",
+            "image": "zookeeper:3.4.8",
             "name": "server",
             "ports": [
               {

--- a/log4j.properties
+++ b/log4j.properties
@@ -1,0 +1,63 @@
+# Define some default values that can be overridden by system properties
+zookeeper.root.logger=INFO, CONSOLE
+zookeeper.console.threshold=INFO
+zookeeper.log.dir=.
+zookeeper.log.file=zookeeper.log
+zookeeper.log.threshold=DEBUG
+zookeeper.tracelog.dir=.
+zookeeper.tracelog.file=zookeeper_trace.log
+
+#
+# ZooKeeper Logging Configuration
+#
+
+# Format is "<default threshold> (, <appender>)+
+
+# DEFAULT: console appender only
+log4j.rootLogger=${zookeeper.root.logger}
+
+# Example with rolling log file
+#log4j.rootLogger=DEBUG, CONSOLE, ROLLINGFILE
+
+# Example with rolling log file and tracing
+#log4j.rootLogger=TRACE, CONSOLE, ROLLINGFILE, TRACEFILE
+
+#
+# Log INFO level and above messages to the console
+#
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.Threshold=${zookeeper.console.threshold}
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+#log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS'Z'} level=%-p, s=rio, component=ZK, hostname=${zookeeper.hostname}, site=${zookeeper.siteid}, ZKID=${zookeeper.zkid}, msg="[myid:%X{myid}] [%t:%C{1}@%L] - %m" %n
+
+
+#
+# Add ROLLINGFILE to rootLogger to get log file output
+#    Log DEBUG level and above messages to a log file
+log4j.appender.ROLLINGFILE=org.apache.log4j.RollingFileAppender
+log4j.appender.ROLLINGFILE.Threshold=${zookeeper.log.threshold}
+log4j.appender.ROLLINGFILE.File=${zookeeper.log.dir}/${zookeeper.log.file}
+
+# Max log file size of 10MB
+log4j.appender.ROLLINGFILE.MaxFileSize=10MB
+# uncomment the next line to limit number of backup files
+#log4j.appender.ROLLINGFILE.MaxBackupIndex=10
+
+log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
+#log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L] - %m%n
+log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS'Z'} level=%-p, s=rio, component=ZK, hostname=${zookeeper.hostname}, site=${zookeeper.siteid}, ZKID=${zookeeper.zkid}, msg="[myid:%X{myid}] [%t:%C{1}@%L] - %m" %n
+
+#
+# Add TRACEFILE to rootLogger to get log file output
+#    Log DEBUG level and above messages to a log file
+log4j.appender.TRACEFILE=org.apache.log4j.FileAppender
+log4j.appender.TRACEFILE.Threshold=TRACE
+log4j.appender.TRACEFILE.File=${zookeeper.tracelog.dir}/${zookeeper.tracelog.file}
+
+log4j.appender.TRACEFILE.layout=org.apache.log4j.PatternLayout
+### Notice we are including log4j's NDC here (%x)
+#log4j.appender.TRACEFILE.layout.ConversionPattern=%d{ISO8601} [myid:%X{myid}] - %-5p [%t:%C{1}@%L][%x] - %m%n
+log4j.appender.TRACEFILE.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS'Z'} level=%-p, s=rio, component=ZK, hostname=${zookeeper.hostname}, site=${zookeeper.siteid}, ZKID=${zookeeper.zkid}, msg="[myid:%X{myid}] [%t:%C{1}@%L] - %m" %n
+
+

--- a/zkServer.sh
+++ b/zkServer.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# If this scripted is run out of /usr/bin or some other system bin directory
+# it should be linked to and not copied. Things like java jar files are found
+# relative to the canonical path of this script.
+#
+
+# See the following page for extensive details on setting
+# up the JVM to accept JMX remote management:
+# http://java.sun.com/javase/6/docs/technotes/guides/management/agent.html
+# by default we allow local JMX connections
+if [ "x$JMXLOCALONLY" = "x" ]
+then
+    JMXLOCALONLY=false
+fi
+
+if [ "x$JMXDISABLE" = "x" ]
+then
+    echo "JMX enabled by default" >&2
+    # for some reason these two options are necessary on jdk6 on Ubuntu
+    #   accord to the docs they are not necessary, but otw jconsole cannot
+    #   do a local attach
+    ZOOMAIN="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.local.only=$JMXLOCALONLY org.apache.zookeeper.server.quorum.QuorumPeerMain"
+else
+    echo "JMX disabled by user request" >&2
+    ZOOMAIN="org.apache.zookeeper.server.quorum.QuorumPeerMain"
+fi
+
+# use POSTIX interface, symlink is followed automatically
+ZOOBIN="${BASH_SOURCE-$0}"
+ZOOBIN="$(dirname "${ZOOBIN}")"
+ZOOBINDIR="$(cd "${ZOOBIN}"; pwd)"
+
+if [ -e "$ZOOBIN/../libexec/zkEnv.sh" ]; then
+  . "$ZOOBINDIR"/../libexec/zkEnv.sh
+else
+  . "$ZOOBINDIR"/zkEnv.sh
+fi
+
+if [ "x$SERVER_JVMFLAGS" != "x" ]
+then
+    JVMFLAGS="$SERVER_JVMFLAGS $JVMFLAGS"
+fi
+
+if [ "x$2" != "x" ]
+then
+    ZOOCFG="$ZOOCFGDIR/$2"
+fi
+
+# if we give a more complicated path to the config, don't screw around in $ZOOCFGDIR
+if [ "x$(dirname "$ZOOCFG")" != "x$ZOOCFGDIR" ]
+then
+    ZOOCFG="$2"
+fi
+
+if $cygwin
+then
+    ZOOCFG=`cygpath -wp "$ZOOCFG"`
+    # cygwin has a "kill" in the shell itself, gets confused
+    KILL=/bin/kill
+else
+    KILL=kill
+fi
+
+echo "Using config: $ZOOCFG" >&2
+
+ZOO_DATADIR="$(grep "^[[:space:]]*dataDir" "$ZOOCFG" | sed -e 's/.*=//')"
+ZOO_DATALOGDIR="$(grep "^[[:space:]]*dataLogDir" "$ZOOCFG" | sed -e 's/.*=//')"
+
+# iff autocreate is turned off and the datadirs don't exist fail
+# immediately as we can't create the PID file, etc..., anyway.
+if [ -n "$ZOO_DATADIR_AUTOCREATE_DISABLE" ]; then
+    if [ ! -d "$ZOO_DATADIR/version-2" ]; then
+        echo "ZooKeeper data directory is missing at $ZOO_DATADIR fix the path or run initialize"
+        exit 1
+    fi
+
+    if [ -n "$ZOO_DATALOGDIR" ] && [ ! -d "$ZOO_DATALOGDIR/version-2" ]; then
+        echo "ZooKeeper txnlog directory is missing at $ZOO_DATALOGDIR fix the path or run initialize"
+        exit 1
+    fi
+    ZOO_DATADIR_AUTOCREATE="-Dzookeeper.datadir.autocreate=false"
+fi
+
+if [ -z "$ZOOPIDFILE" ]; then
+    if [ ! -d "$ZOO_DATADIR" ]; then
+        mkdir -p "$ZOO_DATADIR"
+    fi
+    ZOOPIDFILE="$ZOO_DATADIR/zookeeper_server.pid"
+else
+    # ensure it exists, otw stop will fail
+    mkdir -p "$(dirname "$ZOOPIDFILE")"
+fi
+
+if [ ! -w "$ZOO_LOG_DIR" ] ; then
+mkdir -p "$ZOO_LOG_DIR"
+fi
+
+_ZOO_DAEMON_OUT="$ZOO_LOG_DIR/zookeeper.out"
+
+case $1 in
+start)
+    echo  -n "Starting zookeeper ... "
+    if [ -f "$ZOOPIDFILE" ]; then
+      if kill -0 `cat "$ZOOPIDFILE"` > /dev/null 2>&1; then
+         echo $command already running as process `cat "$ZOOPIDFILE"`.
+         exit 0
+      fi
+    fi
+    nohup "$JAVA" $ZOO_DATADIR_AUTOCREATE "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" \
+    "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
+    "-Dzookeeper.zkid=${MYID}" \
+    "-Dzookeeper.hostname=${HOSTNAME}" \
+    "-Dzookeeper.siteid=${SITE_ID}" \
+    -cp "$CLASSPATH" $JVMFLAGS $ZOOMAIN "$ZOOCFG" > "$_ZOO_DAEMON_OUT" 2>&1 < /dev/null &
+    if [ $? -eq 0 ]
+    then
+      if /bin/echo -n $! > "$ZOOPIDFILE"
+      then
+        sleep 1
+        echo STARTED
+      else
+        echo FAILED TO WRITE PID
+        exit 1
+      fi
+    else
+      echo SERVER DID NOT START
+      exit 1
+    fi
+    ;;
+start-foreground)
+    ZOO_CMD=(exec "$JAVA")
+    if [ "${ZOO_NOEXEC}" != "" ]; then
+      ZOO_CMD=("$JAVA")
+    fi
+    "${ZOO_CMD[@]}" $ZOO_DATADIR_AUTOCREATE "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" \
+    "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
+    "-Dzookeeper.zkid=${MYID}" \
+    "-Dzookeeper.hostname=${HOSTNAME}" \
+    "-Dzookeeper.siteid=${SITE_ID}" \
+    -cp "$CLASSPATH" $JVMFLAGS $ZOOMAIN "$ZOOCFG"
+    ;;
+print-cmd)
+    echo "\"$JAVA\" $ZOO_DATADIR_AUTOCREATE -Dzookeeper.log.dir=\"${ZOO_LOG_DIR}\" -Dzookeeper.root.logger=\"${ZOO_LOG4J_PROP}\" -Dzookeeper.zkid=\"${MYID}\" -Dzookeeper.hostname=\"${HOSTNAME}\" -Dzookeeper.siteid=\"${SITE_ID}\" -cp \"$CLASSPATH\" $JVMFLAGS $ZOOMAIN \"$ZOOCFG\" > \"$_ZOO_DAEMON_OUT\" 2>&1 < /dev/null"
+    ;;
+stop)
+    echo -n "Stopping zookeeper ... "
+    if [ ! -f "$ZOOPIDFILE" ]
+    then
+      echo "no zookeeper to stop (could not find file $ZOOPIDFILE)"
+    else
+      $KILL -9 $(cat "$ZOOPIDFILE")
+      rm "$ZOOPIDFILE"
+      echo STOPPED
+    fi
+    exit 0
+    ;;
+restart)
+    shift
+    "$0" stop ${@}
+    sleep 3
+    "$0" start ${@}
+    ;;
+status)
+    # -q is necessary on some versions of linux where nc returns too quickly, and no stat result is output
+    clientPortAddress=`grep "^[[:space:]]*clientPortAddress[^[:alpha:]]" "$ZOOCFG" | sed -e 's/.*=//'`
+    if ! [ $clientPortAddress ]
+    then
+	clientPortAddress="localhost"
+    fi
+    clientPort=`grep "^[[:space:]]*clientPort[^[:alpha:]]" "$ZOOCFG" | sed -e 's/.*=//'`
+    if ! [ $clientPort ]
+    then
+       echo "Client port not found in static config file. Looking in dynamic config file."
+       dataDir=`grep "^[[:space:]]*dataDir" "$ZOOCFG" | sed -e 's/.*=//'`
+       myid=`cat "$dataDir/myid"`
+       dynamicConfigFile=`grep "^[[:space:]]*dynamicConfigFile" "$ZOOCFG" | sed -e 's/.*=//'`
+       clientPort=`grep "^[[:space:]]*server.$myid" "$dynamicConfigFile" | sed -e 's/.*=//' | sed -e 's/.*;//' | sed -e 's/.*://'`
+       if ! [[ "$clientPort" =~ ^[0-9]+$ ]] ; then
+          echo "Client port not found. Terminating."
+          exit 1
+       fi
+    fi
+    echo "Client port found: $clientPort"
+    STAT=`"$JAVA" "-Dzookeeper.log.dir=${ZOO_LOG_DIR}" "-Dzookeeper.root.logger=${ZOO_LOG4J_PROP}" \
+             "-Dzookeeper.zkid=${MYID}" \
+             "-Dzookeeper.hostname=${HOSTNAME}" \
+             "-Dzookeeper.siteid=${SITE_ID}" \
+             -cp "$CLASSPATH" $JVMFLAGS org.apache.zookeeper.client.FourLetterWordMain \
+             $clientPortAddress $clientPort srvr 2> /dev/null    \
+          | grep Mode`
+    if [ "x$STAT" = "x" ]
+    then
+        echo "Error contacting service. It is probably not running."
+        exit 1
+    else
+        echo $STAT
+        exit 0
+    fi
+    ;;
+*)
+    echo "Usage: $0 [--config <conf-dir>] {start|start-foreground|stop|restart|status|upgrade|print-cmd}" >&2
+
+esac


### PR DESCRIPTION
#Background:
Currently ZK logs don't get picked up by splunk since the formatting doesnt match the expected format by Splunk. This severely limits our ability to troubleshoot ZK quorum issues.

##Current ZK console log format:
2017-12-09 00:10:41,411 [myid:] - INFO  [main:ZooKeeperServerMain@96] - Starting server

##ZK console log sample after changes:
2017-12-15 01:56:54,467Z level=INFO, s=rio, component=ZK, hostname=zookeeper-02-zj25t, site=Cisco, ZKID=2, msg="[myid:] [NIOServerCxn.Factory:0.0.0.0/0.0.0.0:2181:NIOServerCnxnFactory@192] - Accepted socket connection from /10.10.144.6:57822"


